### PR TITLE
PSR2 updates for Composer2.0 and Laravel 8 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.phar
 composer.lock
 .DS_Store
 .idea/
+.php_cs.dist
+.php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "acaronlex/laravel-calendar",
     "description": "Laravel helper for FullCalendar.io",
     "license": "MIT",
+    "type": "package",
     "authors": [
         {
             "name": "acaronlex",
@@ -10,11 +11,11 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "illuminate/support": "~7.0"
+        "illuminate/support": "~7.0|~8.0"
     },
     "autoload": {
-        "psr-0": {
-            "Acaronlex\\LaravelCalendar": "src/"
+        "psr-4": {
+            "Acaronlex\\LaravelCalendar\\": "src"
         }
     },
     "extra": {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Laravel 7 Full Calendar 5 Helper
+# Laravel 7 & 8 Full Calendar 5 Helper
 
 This is a simple helper package to make generating [http://fullcalendar.io](http://fullcalendar.io) in Laravel apps easier.
 
@@ -239,6 +239,6 @@ Then to display, add the following code to your View:
 </body>
 </html>
 ```
-**Note:** The output from `calendar()` and `script()` must be non-escaped, so use `{!!` and `!!}` (or whatever you've configured your Blade compiler's raw tag directives as).   
+**Note:** The output from `calendar()` and `script()` must be non-escaped, so use `{!!` and `!!}` (or whatever you've configured your Blade compiler's raw tag directives as).
 
 The `script()` can be placed anywhere after `calendar()`, and must be after fullcalendar was included.

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -1,4 +1,6 @@
-<?php namespace Acaronlex\LaravelCalendar;
+<?php
+
+namespace Acaronlex\LaravelCalendar;
 
 use ArrayAccess;
 use DateTime;
@@ -8,7 +10,6 @@ use View;
 
 class Calendar
 {
-
     /**
      * @var Factory
      */
@@ -123,7 +124,7 @@ class Calendar
      */
     public function getId()
     {
-        if ( ! empty($this->id)) {
+        if (! empty($this->id)) {
             return $this->id;
         }
 
@@ -231,7 +232,6 @@ class Calendar
         }
 
         return $json;
-
     }
 
     /**
@@ -270,5 +270,4 @@ class Calendar
 
         return str_replace($search, $replace, $json);
     }
-
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -1,4 +1,6 @@
-<?php namespace Acaronlex\LaravelCalendar;
+<?php
+
+namespace Acaronlex\LaravelCalendar;
 
 use DateTime;
 
@@ -31,5 +33,4 @@ interface Event
      * @return DateTime
      */
     public function getEnd();
-
 }

--- a/src/EventCollection.php
+++ b/src/EventCollection.php
@@ -1,10 +1,11 @@
-<?php namespace Acaronlex\LaravelCalendar;
+<?php
+
+namespace Acaronlex\LaravelCalendar;
 
 use Illuminate\Support\Collection;
 
 class EventCollection
 {
-
     /**
      * @var Collection
      */

--- a/src/IdentifiableEvent.php
+++ b/src/IdentifiableEvent.php
@@ -1,13 +1,13 @@
-<?php namespace Acaronlex\LaravelCalendar;
+<?php
+
+namespace Acaronlex\LaravelCalendar;
 
 interface IdentifiableEvent extends Event
 {
-
     /**
      * Get the event's ID
      *
      * @return int|string|null
      */
     public function getId();
-
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,10 +1,11 @@
-<?php namespace Acaronlex\LaravelCalendar;
+<?php
+
+namespace Acaronlex\LaravelCalendar;
 
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
 {
-
     /**
      * Register the service provider.
      *
@@ -31,6 +32,4 @@ class ServiceProvider extends BaseServiceProvider
     {
         return ['laravel-calendar'];
     }
-
 }
-

--- a/src/SimpleEvent.php
+++ b/src/SimpleEvent.php
@@ -1,4 +1,6 @@
-<?php namespace Acaronlex\LaravelCalendar;
+<?php
+
+namespace Acaronlex\LaravelCalendar;
 
 use DateTime;
 
@@ -11,7 +13,6 @@ use DateTime;
  */
 class SimpleEvent implements IdentifiableEvent
 {
-
     /**
      * @var string|int|null
      */

--- a/src/facades/Calendar.php
+++ b/src/facades/Calendar.php
@@ -1,10 +1,11 @@
-<?php namespace Acaronlex\LaravelCalendar\Facades;
+<?php
+
+namespace Acaronlex\LaravelCalendar\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
 class Calendar extends Facade
 {
-
     protected static function getFacadeAccessor()
     {
         return 'laravel-calendar';


### PR DESCRIPTION
Solves issue https://github.com/GrandpaFizz/laravel-calendar/issues/6:

```
Generating optimized autoload files
Deprecation Notice: Class Acaronlex\LaravelCalendar\CalendarFacade located in ./vendor/acaronlex/laravel-calendar/src/CalendarFacade.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Acaronlex\LaravelCalendar\Event located in ./vendor/acaronlex/laravel-calendar/src/Event.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Acaronlex\LaravelCalendar\Calendar located in ./vendor/acaronlex/laravel-calendar/src/Calendar.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Acaronlex\LaravelCalendar\ServiceProvider located in ./vendor/acaronlex/laravel-calendar/src/ServiceProvider.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Acaronlex\LaravelCalendar\SimpleEvent located in ./vendor/acaronlex/laravel-calendar/src/SimpleEvent.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Acaronlex\LaravelCalendar\IdentifiableEvent located in ./vendor/acaronlex/laravel-calendar/src/IdentifiableEvent.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Acaronlex\LaravelCalendar\EventCollection located in ./vendor/acaronlex/laravel-calendar/src/EventCollection.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
```
