### PR TITLE
FullCalendar v5.x Compatible

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -31,12 +31,14 @@ class Calendar
      * @var array
      */
     protected $defaultOptions = [
-        'header' => [
+        'initialView'=> 'dayGridMonth',
+        'height' => 'auto',
+        'headerToolbar' => [
             'left' => 'prev,next today',
             'center' => 'title',
-            'right' => 'month,agendaWeek,agendaDay',
+            'right' => 'dayGridMonth,dayGridWeek,listWeek',
         ],
-        'eventLimit' => true,
+        'dayMaxEventRows' => true,
     ];
 
     /**


### PR DESCRIPTION
FullCalendar v4.x brought some breaking changes such as 'agenda' views renamed to 'timeGrid' views. The MonthView class is no longer exposed, the functionality has been rolled into DayGridView.
Check out - https://fullcalendar.io/docs/v4/upgrading-from-v3

FullCalendar v5.x further went on renaming, such as 'defaultView' is 'initialView' and 'header' is 'headerToolbar' now.
Check out - https://fullcalendar.io/docs/upgrading-from-v4