### PR TITLE
ES6 support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,10 +27,10 @@ $event = \Calendar::event(
     true, //full day event?
     '2015-02-14', //start time, must be a DateTime object or valid DateTime format (http://bit.ly/1z7QWbg)
     '2015-02-14', //end time, must be a DateTime object or valid DateTime format (http://bit.ly/1z7QWbg),
-	1, //optional event ID
-	[
-		'url' => 'http://full-calendar.io'
-	]
+    1, //optional event ID
+    [
+        'url' => 'http://full-calendar.io'
+    ]
 );
 ```
 #### Implementing `Event` Interface
@@ -102,7 +102,7 @@ If you wish for your existing class to have event IDs, implement `\Acaronlex\Lar
 class EventModel extends Eloquent implements \Acaronlex\LaravelCalendar\IdentifiableEvent
 {
 
-	// Implement all Event methods ...
+    // Implement all Event methods ...
 
     /**
      * Get the event's ID
@@ -129,11 +129,11 @@ $event = \Calendar::event(
     true, //full day event?
     '2015-02-14', //start time, must be a DateTime object or valid DateTime format (http://bit.ly/1z7QWbg)
     '2015-02-14', //end time, must be a DateTime object or valid DateTime format (http://bit.ly/1z7QWbg),
-	1, //optional event ID
-	[
-		'url' => 'http://full-calendar.io',
-		//any other full-calendar supported parameters
-	]
+    1, //optional event ID
+    [
+        'url' => 'http://full-calendar.io',
+        //any other full-calendar supported parameters
+    ]
 );
 
 ```
@@ -144,9 +144,9 @@ $event = \Calendar::event(
 <?php
 class CalendarEvent extends \Illuminate\Database\Eloquent\Model implements \Acaronlex\LaravelCalendar\Event
 {
-	//...
+    //...
 
-	/**
+    /**
      * Optional FullCalendar.io settings for this event
      *
      * @return array
@@ -159,7 +159,7 @@ class CalendarEvent extends \Illuminate\Database\Eloquent\Model implements \Acar
         ];
     }
 
-	//...
+    //...
 }
 
 ```
@@ -167,7 +167,7 @@ class CalendarEvent extends \Illuminate\Database\Eloquent\Model implements \Acar
 ### Create a Calendar
 To create a calendar, in your route or controller, create your event(s), then pass them to `Calendar::addEvent()` or `Calendar::addEvents()` (to add an array of events). `addEvent()` and `addEvents()` can be used fluently (chained together). Their second parameter accepts an array of valid [FullCalendar Event Object parameters](http://fullcalendar.io/docs/event_data/Event_Object/).
 
-#### Sample Controller code:
+#### Sample Controller code (Using Script Tags and Browser Globals)
 
 ```php
 $events = [];
@@ -189,28 +189,106 @@ $events[] = \Calendar::event(
 );
 
 $calendar = new Calendar();
-        $calendar->addEvents($events)
-        ->setOptions([
-            'locale' => 'fr',
-            'firstDay' => 0,
-            'displayEventTime' => true,
-            'selectable' => true,
-            'initialView' => 'timeGridWeek',
-            'headerToolbar' => [
-                'end' => 'today prev,next dayGridMonth timeGridWeek timeGridDay'
-            ]
-        ]);
-        $calendar->setId('1');
-        $calendar->setCallbacks([
-            'select' => 'function(selectionInfo){}',
-            'eventClick' => 'function(event){}'
-        ]);
+$calendar->addEvents($events);
+$calendar->setOptions([
+    'locales' => 'allLocales',
+    'locale' => 'fr',
+    'firstDay' => 0,
+    'displayEventTime' => true,
+    'selectable' => true,
+    'initialView' => 'timeGridWeek',
+    'headerToolbar' => [
+        'left' => 'prev,next today myCustomButton',
+        'center' => 'title',
+        'right' => 'dayGridMonth,timeGridWeek,timeGridDay'
+    ],
+    'customButtons' => [
+        'myCustomButton' => [
+            'text'=> 'custom!',
+            'click' => 'function() {
+                alert(\'clicked the custom button!\');
+            }'
+        ]
+    ]
+]);
+$calendar->setId('1');
+$calendar->setCallbacks([
+    'select' => 'function(selectionInfo){}',
+    'eventClick' => 'function(event){}'
+]);
+
+return view('hello', compact('calendar'));
+```
+
+#### Sample Controller code (Using ES6 build system)
+
+```php
+$events = [];
+
+$events[] = \Calendar::event(
+    'Event One', //event title
+    false, //full day event?
+    '2015-02-11T0800', //start time (you can also use Carbon instead of DateTime)
+    '2015-02-12T0800', //end time (you can also use Carbon instead of DateTime)
+    0 //optionally, you can specify an event ID
+);
+
+$events[] = \Calendar::event(
+    "Valentine's Day", //event title
+    true, //full day event?
+    new \DateTime('2015-02-14'), //start time (you can also use Carbon instead of DateTime)
+    new \DateTime('2015-02-14'), //end time (you can also use Carbon instead of DateTime)
+    'stringEventId' //optionally, you can specify an event ID
+);
+
+$calendar = new Calendar();
+$calendar->addEvents($events)
+->setOptions([
+    'plugins' => [ 'window.interaction', 'window.momentPlugin', 'window.dayGridPlugin', 'window.timeGridPlugin', 'window.listPlugin' ],
+    'locales' => 'window.allLocales',
+    'locale' => 'fr',
+    'firstDay' => 0,
+    'displayEventTime' => true,
+    'selectable' => true,
+    'initialView' => 'timeGridWeek',
+    'headerToolbar' => [
+        'left' => 'prev,next today myCustomButton',
+        'center' => 'title',
+        'right' => 'dayGridMonth,timeGridWeek,timeGridDay'
+    ],
+    'customButtons' => [
+        'myCustomButton' => [
+            'text'=> 'custom!',
+            'click' => 'function() {
+                alert(\'clicked the custom button!\');
+            }'
+        ]
+    ]
+]);
+$calendar->setId('1');
+$calendar->setEs6();
+$calendar->setCallbacks([
+    'select' => 'function(info) {
+        alert(\'selected \' + info.startStr + \' to \' + info.endStr);
+    }',
+    'eventClick' => 'function(info) {
+        alert(\'Event: \' + info.event.title);
+        alert(\'Coordinates: \' + info.jsEvent.pageX + \',\' + info.jsEvent.pageY);
+        alert(\'View: \' + info.view.type);
+        
+        // change the border color just for fun
+        info.el.style.borderColor = \'red\';
+    }',
+    'dateClick' => 'function(info) {
+        alert(\'clicked \' + info.dateStr);
+    }'
+]);
 
 return view('hello', compact('calendar'));
 ```
 
 
-#### Sample View
+#### Sample View (Using Script Tags and Browser Globals)
 
 Then to display, add the following code to your View:
 
@@ -218,13 +296,14 @@ Then to display, add the following code to your View:
 <!doctype html>
 <html lang="en">
 <head>
-	<script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-	<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.9.0/moment.min.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.5.0/main.min.js"></script>
-
-    	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.5.0/main.css"/>
-
-
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.9.0/moment.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.5.0/main.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.5.0/locales-all.min.js"></script>
+	
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.5.0/main.css"/>
+    
+    
     <style>
         /* ... */
     </style>
@@ -235,6 +314,68 @@ Then to display, add the following code to your View:
 </body>
 </html>
 ```
+
+#### Sample View (Using ES6 build system)
+
+In your `/resources/js/app.js` add any necessary plugins after installing them with NPM.
+
+```php
+// FullCalendar.io
+import { Calendar } from '@fullcalendar/core';
+window.Calendar = Calendar;
+
+import interaction from '@fullcalendar/interaction';
+window.interaction = interaction;
+
+import dayGridPlugin from '@fullcalendar/daygrid';
+window.dayGridPlugin = dayGridPlugin;
+
+import timeGridPlugin from '@fullcalendar/timegrid';
+window.timeGridPlugin = timeGridPlugin;
+
+import listPlugin from '@fullcalendar/list';
+window.listPlugin = listPlugin;
+
+import momentPlugin from '@fullcalendar/moment';
+window.momentPlugin = momentPlugin;
+
+import allLocales from '@fullcalendar/core/locales-all';
+window.allLocales = allLocales;
+```
+
+In your `resources/css/app.scss` add the necessary CSS.
+
+```
+// Fullcalendar
+@import '~@fullcalendar/bootstrap/main.css';
+@import '~@fullcalendar/daygrid/main.css';
+@import '~@fullcalendar/timegrid/main.css';
+@import '~@fullcalendar/list/main.css';
+```
+
+
+Then in your blade view file output the HTML:
+
+```php
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="{{ mix('/css/app.css') }}" rel="stylesheet">
+    
+    <script src="{{ mix('/js/app.js') }}"></script>
+</head>
+<body>
+    {!! $calendar->calendar() !!}
+    {!! $calendar->script() !!}
+</body>
+</html>
+```
+
+#### Notes
+
 **Note:** The output from `calendar()` and `script()` must be non-escaped, so use `{!!` and `!!}` (or whatever you've configured your Blade compiler's raw tag directives as).
 
 The `script()` can be placed anywhere after `calendar()`, and must be after fullcalendar was included.
+

--- a/src/views/script-es6.blade.php
+++ b/src/views/script-es6.blade.php
@@ -1,0 +1,10 @@
+<script>
+    let calendar;
+    document.addEventListener('DOMContentLoaded', function() {
+        let calendarEl = document.getElementById('calendar-{{ $id }}')
+        calendar = new Calendar(calendarEl,
+            {!! $options !!},
+        );
+        calendar.render();
+    });
+</script>


### PR DESCRIPTION
This covers everything needed to get Laravel to use ES6 version of FullCalendar.io. It also solves issues of configuration by escaping double quotes for certain fields required in the FullCalendar Object. This now allows the use of customButtons with callback functions.

The additions included won't break current version.

- added ES6 Support #20
- added `replaceKeys($json)` function to Calendar class to format JSON string to Javascript Object
- added support for `customButtons` option from FullCalendar.io #21 
- added script-es6.blade.php view
- added flag `JSON_PRETTY_PRINT` for JSON output to be readable in the script output
- updated `ReadMe` to reflect changes
- added use of `allLocales` in examples